### PR TITLE
Ignores the 'dist' directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependências
 node_modules
+dist
 
 # Ambiente
 .env


### PR DESCRIPTION
Prevents the 'dist' directory, which typically contains build artifacts, from being tracked by Git. This avoids committing generated files and keeps the repository cleaner.