### PR TITLE
feat: Adds language support to the portfolio

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -29,6 +29,7 @@ model PortfolioContent {
   home     String
   menu     String[]
   projects String
+  icon     String
   
   // Relacionamentos
   about    PortfolioContentAbout?   @relation(fields: [aboutId], references: [id])

--- a/backend/src/contents/contents.controller.ts
+++ b/backend/src/contents/contents.controller.ts
@@ -30,6 +30,16 @@ export class ContentsController {
     return content;
   }
 
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async getAllLanguages() {
+    const content = await this.contentsService.getAllLanguages();
+    if (!content) {
+      throw new HttpException('Content not found', HttpStatus.NOT_FOUND);
+    }
+    return content;
+  }
+
   @Post('')
   @HttpCode(HttpStatus.CREATED)
   @UseGuards(AdminGuard)
@@ -44,10 +54,10 @@ export class ContentsController {
     @Param('language') language: string,
     @Body() updateContentDto: UpdateContentDto,
   ) {
-    const content = await this.contentsService.updateContent({
-      ...updateContentDto,
+    const content = await this.contentsService.updateContent(
       language,
-    });
+      updateContentDto,
+    );
     if (!content) {
       throw new HttpException('Content not found', HttpStatus.NOT_FOUND);
     }

--- a/backend/src/contents/contents.service.ts
+++ b/backend/src/contents/contents.service.ts
@@ -7,16 +7,41 @@ import { UpdateContentDto } from './dto/update-content.dto';
 export class ContentsService {
   constructor(private prisma: PrismaService) {}
 
-  async getContent(language: string = 'pt-BR') {
-    const content = this.prisma.portfolioContent.findUnique({
+  async getContent(language: string) {
+    const content = await this.prisma.portfolioContent.findUnique({
       where: { language },
+      select: {
+        language: true,
+        home: true,
+        menu: true,
+        projects: true,
+        icon: true,
+        about: {
+          include: {
+            experience: true,
+            education: true,
+          },
+        },
+        skills: true,
+        contact: true,
+      },
     });
     return content;
   }
 
-  async updateContent(updateContentDto: UpdateContentDto) {
+  async getAllLanguages() {
+    const languages = await this.prisma.portfolioContent.findMany({
+      select: {
+        language: true,
+        icon: true,
+      },
+    });
+    return languages;
+  }
+
+  async updateContent(language: string, updateContentDto: UpdateContentDto) {
     return this.prisma.portfolioContent.update({
-      where: { language: updateContentDto.language },
+      where: { language },
       data: updateContentDto,
     });
   }

--- a/backend/src/contents/dto/create-content.dto.ts
+++ b/backend/src/contents/dto/create-content.dto.ts
@@ -5,6 +5,7 @@ export class CreateContentDto {
   home: string;
   menu: string[];
   projects: string;
+  icon: string;
   about: Prisma.PortfolioContentAboutCreateNestedOneWithoutContentInput;
   skills: Prisma.PortfolioContentSkillsCreateNestedOneWithoutContentInput;
   contact: Prisma.PortfolioContentContactCreateNestedOneWithoutContentInput;

--- a/frontend/app/components/LanguageBtn.tsx
+++ b/frontend/app/components/LanguageBtn.tsx
@@ -2,47 +2,55 @@
 import React from 'react';
 import Image from 'next/image';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './dropdown-menu';
-import { PortfolioContent } from '@/app/types';
-
-const iconsUrl = {
-  'pt-Br': 'https://img.icons8.com/fluency/240/brazil-circular.png',
-  'en': 'https://img.icons8.com/fluency/240/usa-circular.png'
-}
+import { usePortfolio } from '../context/PortfolioContext';
+import { Language } from '../types';
 
 interface LanguageBtnProps {
-  content: PortfolioContent[] | null;
-  setLanguage: React.Dispatch<React.SetStateAction<string>>;
+  currentLanguage: string;
+  setCurrentLanguage: (language: string) => void;
 }
 
-const LanguageBtn = ({ content,setLanguage }: LanguageBtnProps) => {
+const LanguageBtn = ({ currentLanguage, setCurrentLanguage }: LanguageBtnProps) => {
+  const { languages, refreshContent } = usePortfolio();
 
-  const languageOptions = content?.map((content) => content.language) || [];
+  const languageOptions = languages.filter((language: Language) => language.language !== currentLanguage);
 
-  const handlePlace = () => {
-    for (let i = 0; i < languageOptions?.length; i++) {
-      if (languageOptions[i] === 'pt-Br') {
-        return 'Brazil';
-      } else if (languageOptions[i] === 'en') {
-        return 'USA';
-      }
-    }
-    return 'Brazil';
+  const currentLanguageData = languages.find((language: Language) => language.language === currentLanguage);
+  const currentIcon = currentLanguageData?.icon;
+
+  if (!currentIcon) {
+    return null;
   }
 
-  const handleLanguageChange = async (e: string) => {
-    setLanguage(e);
+  const handleLanguageChange = async (language: string) => {
+    refreshContent(language);
+    setCurrentLanguage(language);
   }
 
   return (
-    <div className='fixed top-4 right-6 z-50'>
+    <div className='fixed top-2 right-2 md:top-4 md:right-6 z-50'>
       <DropdownMenu>
-        <DropdownMenuTrigger>
-          Language
+        <DropdownMenuTrigger className='w-8 h-8 md:w-12 md:h-12 rounded-full'>
+          <Image width={240} height={240} src={currentIcon} alt={`A flag corresponding to ${currentLanguage}`} />
         </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          {languageOptions.map((language) => (
-            <DropdownMenuItem className='w-12 h-12' key={language} onClick={() => handleLanguageChange(language)}>
-              <Image width={240} height={240} src={iconsUrl[language as keyof typeof iconsUrl]} alt={`A flag of ${handlePlace()}`} />
+        <DropdownMenuContent
+          className="overflow-y-auto bg-transparent min-w-auto"
+          align="end"
+          sideOffset={8}
+        >
+          {languageOptions.map((language: Language) => (
+            <DropdownMenuItem 
+              key={language.language} 
+              onClick={() => handleLanguageChange(language.language)}
+              className="p-0 md:p-2"
+            >
+              <Image 
+                width={40} 
+                height={40} 
+                src={language.icon} 
+                alt={`A flag corresponding to ${language.language}`} 
+                className="w-7 h-7 md:w-10 md:h-10"
+              />
             </DropdownMenuItem>
           ))}
         </DropdownMenuContent>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -205,6 +205,19 @@ html {
   z-index: -1; /* Lower than matrix video */
 }
 
+/* Hide scrollbar for Chrome, Safari and Opera */
+*::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+* {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}
+
 @media (max-width: 768px) {
   .section h2 {
       font-size: 2.5rem;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -6,7 +6,6 @@ import { usePortfolio } from '@/app/context/PortfolioContext';
 
 export default function Home() {
   const { content } = usePortfolio();
-  const contentArray = content ? Object.values(content) : null;
 
   const bgUrls: string[] = [
     '/background/first.jpg',
@@ -23,11 +22,12 @@ export default function Home() {
     ) : (
     <div className="relative">
       <Background bgUrls={bgUrls} />
-      <LanguageBtn content={contentArray} setLanguage={setCurrentLanguage} />
+      <LanguageBtn currentLanguage={currentLanguage} setCurrentLanguage={setCurrentLanguage} />
       <div className="content">
         <div className="section" style={{ height: '100vh' }}>
           <div className="section-content">
-            <h2>{content?.[currentLanguage]?.home || ''}</h2>
+            <h2>Section 1</h2>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec metus vel ante tincidunt placerat.</p>
           </div>
         </div>
         <div className="section z-0" style={{ height: '170vh' }}>

--- a/frontend/app/services/languageDetector.ts
+++ b/frontend/app/services/languageDetector.ts
@@ -1,0 +1,70 @@
+const PORTUGUESE_SPEAKING_COUNTRIES = ['BR', 'PT', 'AO', 'MZ', 'GW', 'TL', 'ST', 'CV', 'GQ'];
+
+type GeolocationService = {
+  url: string;
+  getCountryCode: (data: unknown) => string;
+};
+
+const GEOLOCATION_SERVICES: GeolocationService[] = [
+  {
+    url: 'https://ipapi.co/json/',
+    getCountryCode: (data: unknown) => (data as { country: string }).country
+  },
+  {
+    url: 'https://ipwho.is/',
+    getCountryCode: (data: unknown) => (data as { country_code: string }).country_code
+  },
+  {
+    url: 'https://geolocation-db.com/json/',
+    getCountryCode: (data: unknown) => (data as { country_code: string }).country_code
+  }
+];
+
+const detectCountryCode = async (): Promise<string | null> => {
+  for (const service of GEOLOCATION_SERVICES) {
+    try {
+      const response = await fetch(service.url, {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+        },
+      });
+      
+      if (!response.ok) continue;
+      
+      const data = await response.json();
+      const countryCode = service.getCountryCode(data);
+      
+      if (countryCode) {
+        return countryCode.toUpperCase();
+      }
+    } catch (error) {
+      console.warn(`Failed to fetch from ${service.url}:`, error);
+      continue;
+    }
+  }
+  
+  return null;
+};
+
+export const detectUserLanguage = async (): Promise<'pt-BR' | 'en'> => {
+  try {
+    const countryCode = await detectCountryCode();
+    if (countryCode) {
+      return PORTUGUESE_SPEAKING_COUNTRIES.includes(countryCode) ? 'pt-BR' : 'en';
+    }
+  } catch (error) {
+    console.error('Error detecting country code:', error);
+  }
+  
+  if (typeof navigator !== 'undefined') {
+    const browserLanguage = navigator.language;
+    if (browserLanguage) {
+      return browserLanguage.startsWith('pt') ? 'pt-BR' : 'en';
+    }
+  }
+  
+  return 'pt-BR';
+};
+
+export type LanguageCode = 'pt-BR' | 'en';

--- a/frontend/app/types/index.ts
+++ b/frontend/app/types/index.ts
@@ -31,6 +31,7 @@ export interface PortfolioContent {
   home: string;
   menu: string[];
   projects: string;
+  icon: string;
   about?: {
     story: string;
     experience: Experience[];
@@ -66,6 +67,11 @@ export interface Education {
   periodStart: string;
   periodEnd: string;
   relevant: string[];
+}
+
+export interface Language {
+  language: string;
+  icon: string;
 }
 
 export interface AdminCredentials {


### PR DESCRIPTION
Implements multi-language support for the portfolio content.

- Introduces a language selection feature, allowing users to switch between different language versions of the portfolio.
- Fetches and displays content based on the selected language.
- Adds an `icon` field to the `PortfolioContent` model to store the flag icon URL for each language.
- Introduces an API endpoint to retrieve all available languages and their corresponding icons.
- Automatically detects the user's preferred language and displays the portfolio content in that language by default. Falls back to 'pt-BR' if the user's language is not supported.